### PR TITLE
Fixing the issue with the output dir and build variants

### DIFF
--- a/src/main/kotlin/com/jaredsburrows/spoon/SpoonExtension.kt
+++ b/src/main/kotlin/com/jaredsburrows/spoon/SpoonExtension.kt
@@ -34,6 +34,9 @@ open class SpoonExtension { // Extensions cannot be final
     /** Path to output directory. ("$buildDir/spoon-output" by default) */
     var output: String = DEFAULT_OUTPUT_DIRECTORY
 
+    /** Final path to output directory. Need to avoid cross-variant execution conflicts */
+    lateinit var finalOutput: String
+
     /** Whether or not debug logging is enabled. (false by default) */
     var debug: Boolean = false
 

--- a/src/main/kotlin/com/jaredsburrows/spoon/SpoonPlugin.kt
+++ b/src/main/kotlin/com/jaredsburrows/spoon/SpoonPlugin.kt
@@ -48,11 +48,13 @@ class SpoonPlugin : Plugin<Project> {
                     // This is a hack for library projects.
                     // We supply the same apk as an application and instrumentation to the soon runner.
                     task.applicationApk = if (testedOutput is ApkVariantOutput) testedOutput.outputFile else task.instrumentationApk
-                }
-                if (SpoonExtension.DEFAULT_OUTPUT_DIRECTORY == extension.output) {
-                    extension.output = File("${project.buildDir}/${extension.output}", variant.testedVariant.name).path
-                } else {
-                    extension.output = File(extension.output, variant.testedVariant.name).path
+
+                    // Do this only before the Task runs to make sure that finalOutput points to the current variant.
+                    if (SpoonExtension.DEFAULT_OUTPUT_DIRECTORY == extension.output) {
+                        extension.finalOutput = File("${project.buildDir}/${extension.output}", variant.testedVariant.name).path
+                    } else {
+                        extension.finalOutput = File(extension.output, variant.testedVariant.name).path
+                    }
                 }
                 task.extension = extension
             }

--- a/src/main/kotlin/com/jaredsburrows/spoon/SpoonTask.kt
+++ b/src/main/kotlin/com/jaredsburrows/spoon/SpoonTask.kt
@@ -41,7 +41,7 @@ open class SpoonTask : DefaultTask() {
             .setTitle(extension.title)
             .setTestApk(instrumentationApk)
             .addOtherApk(applicationApk)
-            .setOutputDirectory(File(extension.output))
+            .setOutputDirectory(File(extension.finalOutput))
             .setDebug(extension.debug)
             .setNoAnimations(extension.noAnimations)
             .setAdbTimeout(Duration.ofSeconds(extension.adbTimeout.toLong()))
@@ -90,7 +90,7 @@ open class SpoonTask : DefaultTask() {
 
         val success = if (testing) testValue else builder.build().run()
         if (!success && !extension.ignoreFailures) {
-            throw GradleException("Tests failed! See ${extension.output}/index.html")
+            throw GradleException("Tests failed! See ${extension.finalOutput}/index.html")
         }
     }
 }

--- a/src/test/groovy/com/jaredsburrows/spoon/SpoonPluginSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/spoon/SpoonPluginSpec.groovy
@@ -85,7 +85,7 @@ final class SpoonPluginSpec extends BaseSpec {
     then:
     // Supported directly by Spoon's SpoonRunner
     task.extension.title == "My tests"
-    task.extension.output == "spoonTests/debug"
+    task.extension.output == "spoonTests"
     task.extension.debug
     task.extension.noAnimations
     task.extension.adbTimeout == 5000

--- a/src/test/groovy/com/jaredsburrows/spoon/SpoonTaskSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/spoon/SpoonTaskSpec.groovy
@@ -222,7 +222,7 @@ final class SpoonTaskSpec extends BaseSpec {
     def e = thrown(GradleException)
     e.cause instanceof GradleException
     e.cause.message.contains("Tests failed! See")
-    e.cause.message.contains("${project.spoon.output}/index.html")
+    e.cause.message.contains("${project.spoon.finalOutput}/index.html")
 
     where:
     taskName << ["spoonDebugAndroidTest"]

--- a/src/test/groovy/com/jaredsburrows/spoon/SpoonTaskSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/spoon/SpoonTaskSpec.groovy
@@ -37,7 +37,7 @@ final class SpoonTaskSpec extends BaseSpec {
     then:
     // Supported directly by Spoon's SpoonRunner
     task.extension.title == "Spoon Execution"
-    task.extension.output.contains("spoon-output/debug")
+    task.extension.finalOutput.contains("spoon-output/debug")
     !task.extension.debug
     !task.extension.noAnimations
     task.extension.adbTimeout == 600000
@@ -122,7 +122,7 @@ final class SpoonTaskSpec extends BaseSpec {
     then:
     // Supported directly by Spoon's SpoonRunner
     task.extension.title == "Spoon Execution"
-    task.extension.output == "spoonTests/debug"
+    task.extension.finalOutput == "spoonTests/debug"
     task.extension.debug
     task.extension.noAnimations
     task.extension.adbTimeout == 5000


### PR DESCRIPTION
I figured out what was causing the issue https://github.com/jaredsburrows/gradle-spoon-plugin/issues/4.

In SpoonPlugin.kt, while looping throughout the variants and assigning the `extension.output` property, the value calculated for the first variant (`$buildDir/spoon-output/variantA`) would be used as a base for the value for the next variants (resulting in `$buildDir/spoon-output/variantA/variantB`), and since there is only one Extension instance for the whole build, this would be in the end the concatenation for all the possible variants.

Moving the logic of calculating the `extension.output` to the `task.doFirst` block mitigated the problem, since the calculation would only take place before executing Spoon for a specific variant.

But if you would run something like `./gradlew spoonVariantA spoonVariantB`, `extension.output` would be a concatenation again when running spoon for the second variant.

Adding a `finalOutput` field to the extension, that houses the calculated output path (the user-configured one is kept unchanged at `output`) completes the fix.

Unfortunately, I'm not experienced with Groovy and couldn't even get the project tests to run, so please advice me on how to cover this scenario with tests if you'd require them. 