### PR TITLE
Add a clear option to match new spoon runner clear app data feature

### DIFF
--- a/src/main/kotlin/com/jaredsburrows/spoon/SpoonExtension.kt
+++ b/src/main/kotlin/com/jaredsburrows/spoon/SpoonExtension.kt
@@ -85,6 +85,9 @@ open class SpoonExtension { // Extensions cannot be final
   /** Run tests in separate instrumentation calls. */
   var singleInstrumentationCall: Boolean = false
 
+  /** Run 'pm clear' before each test to clear app data before each test. */
+  var clearAppDataBeforeEachTest: Boolean = false
+
   ////////////////////////////////////////////////////
   // Passed in via -e, extra arguments
   ///////////////////////////////////////////////////

--- a/src/main/kotlin/com/jaredsburrows/spoon/SpoonTask.kt
+++ b/src/main/kotlin/com/jaredsburrows/spoon/SpoonTask.kt
@@ -53,6 +53,7 @@ open class SpoonTask : DefaultTask() {
       .setShard(extension.shard)
       .setTerminateAdb(false)
       .setSingleInstrumentationCall(extension.singleInstrumentationCall)
+      .setClearAppDataBeforeEachTest(extension.clearAppDataBeforeEachTest)
 
     // APKs
     if (!testing) {


### PR DESCRIPTION
Adds a configuration option for `--clear-app-data` in Spoon runner. This a is a new feature that runs the `pm clear` command before each test execution so the app always starts with the same empty state. 

The original Spoon PR: https://github.com/square/spoon/pull/535